### PR TITLE
asset 관련 작업

### DIFF
--- a/Electo/Electo/ClassifiedPhotoCell.swift
+++ b/Electo/Electo/ClassifiedPhotoCell.swift
@@ -34,7 +34,6 @@ class ClassifiedPhotoCell: UITableViewCell {
                 break
             }
             imageViews[index].image = photoImages[index]
-            setRasiusImageView(imageView: imageViews[index])
         }
     }
     
@@ -45,11 +44,6 @@ class ClassifiedPhotoCell: UITableViewCell {
         let numOfMoreImages = cellImages.count - Constants.maximumImageView
         moreImagesLabel.text = "+\(numOfMoreImages)"
         moreImagesLabel.isHidden = false
-    }
-    
-    func setRasiusImageView(imageView: UIImageView) {
-//        imageView.layer.cornerRadius = imageView.frame.width / 
-        imageView.clipsToBounds = true
     }
     
     func clearStackView() {

--- a/Electo/Electo/ClassifiedPhotoViewController.swift
+++ b/Electo/Electo/ClassifiedPhotoViewController.swift
@@ -97,7 +97,7 @@ extension ClassifiedPhotoViewController: UITableViewDelegate {
         detailViewController.identifier = "fromClassifiedView"
         let selectedCell = tableView.cellForRow(at: indexPath) as? ClassifiedPhotoCell ?? ClassifiedPhotoCell.init()
         detailViewController.thumbnailImages = selectedCell.cellImages
-        detailViewController.pressedIndexPath = IndexPath.init(row: 0, section: 0)
+        detailViewController.pressedIndexPath = IndexPath(row: 0, section: 0)
         
         show(detailViewController, sender: self)
         

--- a/Electo/Electo/ClassifiedPhotoViewController.swift
+++ b/Electo/Electo/ClassifiedPhotoViewController.swift
@@ -72,10 +72,10 @@ class ClassifiedPhotoViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard segue.identifier == "ModalRemovedPhotoVC" else { return }
         guard let navigationController = segue.destination as? UINavigationController,
-            let removedPhotoViewController = navigationController.topViewController
+            let temporaryPhotoViewController = navigationController.topViewController
                 as? TemporaryPhotoViewController else { return }
         
-        removedPhotoViewController.photoDataSource = photoDataSource
+        temporaryPhotoViewController.photoDataSource = photoDataSource
     }
 }
 
@@ -94,8 +94,10 @@ extension ClassifiedPhotoViewController: UITableViewDelegate {
         detailViewController.selectedSection = indexPath.section
         detailViewController.photoStore = photoDataSource.photoStore
         
+        detailViewController.identifier = "fromClassifiedView"
         let selectedCell = tableView.cellForRow(at: indexPath) as? ClassifiedPhotoCell ?? ClassifiedPhotoCell.init()
         detailViewController.thumbnailImages = selectedCell.cellImages
+        detailViewController.pressedIndexPath = IndexPath.init(row: 0, section: 0)
         
         show(detailViewController, sender: self)
         

--- a/Electo/Electo/Constants.swift
+++ b/Electo/Electo/Constants.swift
@@ -34,4 +34,5 @@ struct Constants {
         
         return documentDirectory.appendingPathComponent(Constants.archiveFileName)
     }()
+    static let numberOfTapsRequired: Int = 2
 }

--- a/Electo/Electo/DetailPhotoCell.swift
+++ b/Electo/Electo/DetailPhotoCell.swift
@@ -7,7 +7,10 @@
 //
 
 import UIKit
+import Photos
 
 class DetailPhotoCell: UICollectionViewCell {
     @IBOutlet var thumbnailImageView: UIImageView!
+    
+    var requestID: PHImageRequestID? = .init()
 }

--- a/Electo/Electo/DetailPhotoCell.swift
+++ b/Electo/Electo/DetailPhotoCell.swift
@@ -12,5 +12,5 @@ import Photos
 class DetailPhotoCell: UICollectionViewCell {
     @IBOutlet var thumbnailImageView: UIImageView!
     
-    var requestID: PHImageRequestID? = .init()
+    var requestID: PHImageRequestID?
 }

--- a/Electo/Electo/DetailPhotoViewController.swift
+++ b/Electo/Electo/DetailPhotoViewController.swift
@@ -19,7 +19,6 @@ class DetailPhotoViewController: UIViewController {
     
     
     var thumbnailImages: [UIImage] = .init()
-    var thumbnailFetchReqeustID: PHImageRequestID?
     var selectedSectionAssets: [PHAsset] = []
     var selectedSection: Int = 0
     var photoStore: PhotoStore?
@@ -116,16 +115,15 @@ extension DetailPhotoViewController: UICollectionViewDataSource {
         let photoAsset = photoAssets[indexPath.item]
         let options = PHImageRequestOptions()
         
-        if let previousRequestID = thumbnailFetchReqeustID {
-            let manager = PHCachingImageManager.default()
+        if let previousRequestID = cell.requestID {
+            let manager = PHImageManager.default()
             manager.cancelImageRequest(previousRequestID)
         }
         
-        thumbnailFetchReqeustID = photoAsset.fetchImage(size: CGSize(width: 50.0, height: 50.0),
+        cell.requestID = photoAsset.fetchImage(size: CGSize(width: 50.0, height: 50.0),
                                                         contentMode: .aspectFill,
                                                         options: options,
                                                         resultHandler: { (requestedImage) in
-                                                            
                                                             cell.thumbnailImageView.image = requestedImage
         })
         return cell

--- a/Electo/Electo/DetailPhotoViewController.swift
+++ b/Electo/Electo/DetailPhotoViewController.swift
@@ -29,7 +29,7 @@ class DetailPhotoViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        firstSetting()
+        displayDetailViewSetting()
     }
 
     
@@ -68,7 +68,7 @@ class DetailPhotoViewController: UIViewController {
         }
     }
     
-    func firstSetting() {
+    func displayDetailViewSetting() {
         self.zoomingScrollView.minimumZoomScale = 1.0
         self.zoomingScrollView.maximumZoomScale = 6.0
         

--- a/Electo/Electo/DetailPhotoViewController.swift
+++ b/Electo/Electo/DetailPhotoViewController.swift
@@ -29,22 +29,12 @@ class DetailPhotoViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.zoomingScrollView.minimumZoomScale = 1.0
-        self.zoomingScrollView.maximumZoomScale = 6.0
-        
-        self.tabBarController?.tabBar.isHidden = true
-        photoAssets = setAsset(identifier)
-        detailImageView.image = thumbnailImages.first
-        
-        collectionView(thumbnailCollectionView, didSelectItemAt: pressedIndexPath)
-        thumbnailCollectionView.selectItem(at: pressedIndexPath, animated: true, scrollPosition: .centeredHorizontally)
+        firstSetting()
     }
+
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        
-        doubleTapRecognizer.numberOfTapsRequired = Constants.numberOfTapsRequired
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        print(zoomingScrollView.zoomScale)
     }
     
     func setAsset(_ identifier: String) -> [PHAsset] {
@@ -78,6 +68,20 @@ class DetailPhotoViewController: UIViewController {
         }
     }
     
+    func firstSetting() {
+        self.zoomingScrollView.minimumZoomScale = 1.0
+        self.zoomingScrollView.maximumZoomScale = 6.0
+        
+        self.tabBarController?.tabBar.isHidden = true
+        photoAssets = setAsset(identifier)
+        detailImageView.image = thumbnailImages.first
+        
+        collectionView(thumbnailCollectionView, didSelectItemAt: pressedIndexPath)
+        thumbnailCollectionView.selectItem(at: pressedIndexPath, animated: true, scrollPosition: .centeredHorizontally)
+        
+        doubleTapRecognizer.numberOfTapsRequired = Constants.numberOfTapsRequired
+    }
+    
     
     //Todo: Selecting removable photos
     @IBAction func selectForRemovePhoto(_ sender: UIButton) {
@@ -99,9 +103,9 @@ class DetailPhotoViewController: UIViewController {
         
     }
     
-    
     @IBAction func doubleTap(_ sender: UITapGestureRecognizer) {
-        detailImageView.contentMode = .scaleAspectFill
+        self.zoomingScrollView.setZoomScale(1.0, animated: true)
+        self.detailImageView.contentMode = .scaleAspectFill
     }
     
 }
@@ -138,7 +142,8 @@ extension DetailPhotoViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         self.detailImageView.contentMode = .scaleAspectFill
-        self.zoomingScrollView.zoomScale = 1.0
+        print(self.zoomingScrollView.zoomScale)
+        self.zoomingScrollView.setZoomScale(1.0, animated: true)
         
         selectedPhotos = indexPath.item
         pressedIndexPath = indexPath
@@ -183,6 +188,11 @@ extension DetailPhotoViewController: UIScrollViewDelegate {
     }
     
     func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
-        detailImageView.contentMode = .scaleAspectFit
+        self.detailImageView.contentMode = .scaleAspectFit
+    }
+    
+    func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        self.zoomingScrollView.setZoomScale(1.0, animated: true)
+        self.detailImageView.contentMode = .scaleAspectFill
     }
 }

--- a/Electo/Electo/Extension.swift
+++ b/Electo/Electo/Extension.swift
@@ -11,7 +11,7 @@ import Photos
 import MapKit
 
 extension PHAsset {
-    func fetchImage(size: CGSize, contentMode: PHImageContentMode,
+    @discardableResult func fetchImage(size: CGSize, contentMode: PHImageContentMode,
                     options: PHImageRequestOptions?, resultHandler: @escaping (UIImage?) -> Void) -> PHImageRequestID {
         var imageRequestID: PHImageRequestID = .init()
         let cachingImageManager = PHCachingImageManager()

--- a/Electo/Electo/PhotoDataSource.swift
+++ b/Electo/Electo/PhotoDataSource.swift
@@ -66,6 +66,7 @@ extension PhotoDataSource: UITableViewDataSource {
     }
 }
 
+// TemporaryPhotoViewController - DataSource
 extension PhotoDataSource: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return temporaryPhotoStore.photoAssets.count
@@ -77,10 +78,10 @@ extension PhotoDataSource: UICollectionViewDataSource {
         let removedPhotoAsset = temporaryPhotoStore.photoAssets[indexPath.item]
         
         removedPhotoAsset.fetchImage(size: CGSize(width: 90, height: 90),
-            contentMode: .aspectFit, options: nil) { removedPhotoImage in
-            guard let removedPhotoImage = removedPhotoImage else { return }
-                        
-            cell.addRemovedImage(removedPhotoImage: removedPhotoImage)
+                                     contentMode: .aspectFit, options: nil) { removedPhotoImage in
+                                        guard let removedPhotoImage = removedPhotoImage else { return }
+                                                
+                                        cell.addRemovedImage(removedPhotoImage: removedPhotoImage)
         }
     
         return cell

--- a/Electo/Electo/TemporaryPhotoViewController.swift
+++ b/Electo/Electo/TemporaryPhotoViewController.swift
@@ -22,6 +22,7 @@ class TemporaryPhotoViewController: UIViewController {
     @IBOutlet weak var buttonForNormalStackView: UIStackView!
     
     var photoDataSource: PhotoDataSource?
+    var tempThumbnailImages: [UIImage] = .init()
     
     fileprivate var selectMode: SelectMode = .off {
         didSet {
@@ -145,10 +146,12 @@ extension TemporaryPhotoViewController: UICollectionViewDelegate {
             guard let detailViewController = storyboard?.instantiateViewController(withIdentifier:  "detailViewController") as? DetailPhotoViewController else { return }
             
             //TODO: 이미지 전체 넘겨주기
-            let selectedCell = collectionView.cellForItem(at: indexPath) as? TemporaryPhotoCell ?? TemporaryPhotoCell()
-
             detailViewController.selectedSectionAssets = temporaryPhotoStore.photoAssets
             detailViewController.identifier = "fromTemporaryViewController"
+            
+            guard let selectedThumbnailImage = photoCell.thumbnailImageView.image else { return }
+            detailViewController.thumbnailImages.append(selectedThumbnailImage)
+            detailViewController.pressedIndexPath = indexPath
             show(detailViewController, sender: self)
         }
     }


### PR DESCRIPTION
- 이전 requestID 취소
- asset으로 넘겨주기(버그 방지 위해 UIImage 배열 유지)
- TemporaryView에서 DetailView로 넘어가면 모든 이미지를 보여주도록 DetailView의 datasource 수정하기